### PR TITLE
Move "Show metadata" button + more enhancements

### DIFF
--- a/python/philologic/runtime/reports/time_series.py
+++ b/python/philologic/runtime/reports/time_series.py
@@ -100,9 +100,10 @@ def get_start_end_date(db, config, start_date=None, end_date=None):
             else:
                 pass
     min_date = min(dates)
+    # Note (thawsitt): Setting default range to 1200-1400
     if not start_date:
-        start_date = min_date
+        start_date = 1200
     max_date = max(dates)
     if not end_date:
-        end_date = max_date
+        end_date = 1400
     return start_date, end_date

--- a/www/app/assets/css/split/default_theme.css
+++ b/www/app/assets/css/split/default_theme.css
@@ -50,7 +50,7 @@ a.export-button:hover {
     text-decoration: none !important;
 }
 
-a.link-on-dark:hover {
+a.link-on-dark {
     color: #fff !important;
 }
 

--- a/www/app/assets/css/split/default_theme.css
+++ b/www/app/assets/css/split/default_theme.css
@@ -50,6 +50,14 @@ a.export-button:hover {
     text-decoration: none !important;
 }
 
+a.link-on-dark:hover {
+    color: #fff !important;
+}
+
+a.link-on-dark:hover {
+    color: #adbcca !important;
+}
+
 #dico-landing-volume li, #dico-landing-alpha td {
 	color: #697683;
 	transition: all 0ms;

--- a/www/app/assets/css/split/textObjectNavigation.css
+++ b/www/app/assets/css/split/textObjectNavigation.css
@@ -733,6 +733,11 @@ table.metadata-table td {
     font-size: 1.5rem;
 }
 
+/*source links in metadata table*/
+table.metadata-table td.metadata-source-link {
+    padding: 10px 5px 10px 5px;
+}
+
 table.metadata-table tr {
     border-bottom: 1px solid #4d4d4d;
 }

--- a/www/app/assets/css/split/textObjectNavigation.css
+++ b/www/app/assets/css/split/textObjectNavigation.css
@@ -677,7 +677,7 @@ b.headword[rend=center] {
   z-index: 9999;
   background: #212121;
   min-width: 250px;
-  max-width: 25%;
+  max-width: 30%;
   padding: 20px;
   overflow-y: scroll;
   color: #fff;

--- a/www/app/assets/css/split/textObjectNavigation.css
+++ b/www/app/assets/css/split/textObjectNavigation.css
@@ -697,7 +697,7 @@ b.headword[rend=center] {
   -webkit-transform: translateX(-100%);
 }
 
-#metadata-panel h2 {
+#metadata-panel-header {
     padding-left: 5px;
     margin-bottom: 30px;
 }

--- a/www/app/components/textNavigation/navigationBar.html
+++ b/www/app/components/textNavigation/navigationBar.html
@@ -10,6 +10,14 @@
                     <span class="glyphicon glyphicon-chevron-left"></span>
                 </button>
                 <button type="button" class="btn btn-primary" id="show-toc" disabled="disabled" ng-click="textNav.toggleTableOfContents()">Table of contents</button>
+                <button
+                    type="button"
+                    id="foo"
+                    class="btn btn-primary"
+                    ng-click="textNav.toggleMetadataPanel($event)"
+                >
+                {{textNav.showMetadataPanel ? "Hide Metadata" : "Show Metadata"}}
+                </button>
                 <button type="button" class="btn btn-primary" disabled="disabled" id="next-obj" ng-click="textNav.goToTextObject(textObject.next)">
                     <span class="glyphicon glyphicon-chevron-right"></span>
                 </button>

--- a/www/app/components/textNavigation/navigationBar.html
+++ b/www/app/components/textNavigation/navigationBar.html
@@ -12,7 +12,6 @@
                 <button type="button" class="btn btn-primary" id="show-toc" disabled="disabled" ng-click="textNav.toggleTableOfContents()">Table of contents</button>
                 <button
                     type="button"
-                    id="foo"
                     class="btn btn-primary"
                     ng-click="textNav.toggleMetadataPanel($event)"
                 >

--- a/www/app/components/textNavigation/textNavigationCtrl.js
+++ b/www/app/components/textNavigation/textNavigationCtrl.js
@@ -138,7 +138,6 @@
 
         vm.toggleMetadataPanel = function(e) {
             vm.showMetadataPanel = !vm.showMetadataPanel;
-            e.target.className = (vm.showMetadataPanel) ? "toggled" : "";
             angular.element('#text-obj-content')[0].style.marginLeft = (vm.showMetadataPanel) ? "30%" : "";
             angular.element('#text-obj-content')[0].style.minWidth = (vm.showMetadataPanel) ? "40vw" : "";
         }

--- a/www/app/components/textNavigation/textNavigationDirectives.js
+++ b/www/app/components/textNavigation/textNavigationDirectives.js
@@ -90,7 +90,7 @@
                     }, '');
 
                     scope.metadataObject = {};
-                    var linkToGuide = '<p id="link-to-documentation">For further guidance, click <a href="https://corpus-synodalium.com/pages/documentation.html" target="_blank">here</a>.</p>';
+                    var linkToGuide = '<p>For further guidance, click <a href="https://corpus-synodalium.com/pages/documentation.html" target="_blank" class="link-on-dark">here</a>.</p>';
                     scope.metadataObject.text = '<div id="metadata-panel-header"><h2>Metadata</h2>' + linkToGuide + '</div><table class="metadata-table"><tbody>' +
                         replacedPTags + '</tbody></table>';
                 })

--- a/www/app/components/textNavigation/textNavigationDirectives.js
+++ b/www/app/components/textNavigation/textNavigationDirectives.js
@@ -84,6 +84,17 @@
                         var colonIndex = text.indexOf(':');
                         var key = text.substring(3, colonIndex);
                         var value = text.substring(colonIndex + 2);
+                        // Convert links in Source_URL and Source_URL2
+                        var getSourceTableRow = function(text, value) {
+                            var url = value.substring(0, value.length - 4);
+                            var link = '<a class="link-on-dark" href="' + url + '" target="_blank">link</a>';
+                            return '<tr><td class="metadata-source-link">' + text + '</td><td class="metadata-source-link">' + link + '</td></tr>';
+                        }
+                        if (key === 'Source_URL') {
+                            return getSourceTableRow('Source 1', value);
+                        } else if (key === 'Source_URL2') {
+                            return getSourceTableRow('Source 2', value);
+                        }
                         return '<tr><td>' + key + '</td><td>' + value + '</td></tr>';
                     }).reduce(function(combined, curr) {
                         return combined.concat(curr);

--- a/www/app/components/textNavigation/textNavigationDirectives.js
+++ b/www/app/components/textNavigation/textNavigationDirectives.js
@@ -90,7 +90,8 @@
                     }, '');
 
                     scope.metadataObject = {};
-                    scope.metadataObject.text = '<h2>Metadata</h2><table class="metadata-table"><tbody>' +
+                    var linkToGuide = '<p id="link-to-documentation">For further guidance, click <a href="https://corpus-synodalium.com/pages/documentation.html" target="_blank">here</a>.</p>';
+                    scope.metadataObject.text = '<div id="metadata-panel-header"><h2>Metadata</h2>' + linkToGuide + '</div><table class="metadata-table"><tbody>' +
                         replacedPTags + '</tbody></table>';
                 })
                 .catch(function(response) {

--- a/www/app/components/textNavigation/textObject.html
+++ b/www/app/components/textNavigation/textObject.html
@@ -13,10 +13,6 @@
                 <div id="previous-graphics" ng-if="beforeGraphicsImgs">
                     <a href="{{ img[0] }}" large-img="{{img[1]}}" class="inline-img" ng-repeat="img in beforeGraphicsImgs track by $index" data-gallery></a>
                 </div>
-                <button 
-                    id="metadata-toggle-btn"
-                    ng-click="textNav.toggleMetadataPanel($event)"
-                >Toggle metadata panel</button>
                 <div
                     id="metadata-panel"
                     class="metadata-panel-box-shadow"

--- a/www/app/index.html
+++ b/www/app/index.html
@@ -26,7 +26,7 @@
             <div class="container-fluid">
                 <div class="navbar-right">
                     <a class="link-on-dark" ng-href="{{::philoConfig.link_to_home_page}}" ng-if="philoConfig.link_to_home_page != ''">Go to home page</a>
-                    <a href="https://artfl-project.uchicago.edu/philologic4">PhiloLogic4</a>
+                    <a class="link-on-dark" href="https://artfl-project.uchicago.edu/philologic4">PhiloLogic4</a>
                 </div>
                 <div class="navbar-left">
                     <a class="link-on-dark" href="https://corpus-synodalium.com/">Project Homepage</a>

--- a/www/app/index.html
+++ b/www/app/index.html
@@ -25,18 +25,18 @@
         <div class="navbar navbar-inverse navbar-static-top" role="navigation">
             <div class="container-fluid">
                 <div class="navbar-right">
-                    <a ng-href="{{::philoConfig.link_to_home_page}}" ng-if="philoConfig.link_to_home_page != ''">Go to home page</a>
+                    <a class="link-on-dark" ng-href="{{::philoConfig.link_to_home_page}}" ng-if="philoConfig.link_to_home_page != ''">Go to home page</a>
                     <a href="https://artfl-project.uchicago.edu/philologic4">PhiloLogic4</a>
                 </div>
                 <div class="navbar-left">
-                    <a href="https://corpus-synodalium.com/">Project Homepage</a>
-                    <a href="https://corpus-synodalium.com/pages/documentation.html">User Guide</a>
+                    <a class="link-on-dark" href="https://corpus-synodalium.com/">Project Homepage</a>
+                    <a class="link-on-dark" href="https://corpus-synodalium.com/pages/documentation.html">User Guide</a>
                 </div>
                 <div class="navbar-header">
-                    <a href="" class="navbar-brand" title="$DBNAME" ng-click="PhiloMain.backToHome()">$DBNAME</a>
+                    <a href="" class="navbar-brand link-on-dark" title="$DBNAME" ng-click="PhiloMain.backToHome()">$DBNAME</a>
                     <h4 style="color: white">Local Ecclesiastical Legislation in Medieval Europe / Législations ecclésiastiques locales dans l’Europe médiévale</h4>
                     <div style="position: relative" ng-if="philoConfig.report_error_link != ''">
-                        <a id="header-report-error" target="_blank" ng-href="{{ philoConfig.report_error_link }}">Report Error</a>
+                        <a id="header-report-error" class="link-on-dark" target="_blank" ng-href="{{ philoConfig.report_error_link }}">Report Error</a>
                     </div>
                 </div>
             </div>

--- a/www/app/shared/searchForm/searchForm.js
+++ b/www/app/shared/searchForm/searchForm.js
@@ -32,7 +32,7 @@
                 collocWordNum: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10'],
                 year_interval: philoConfig.time_series_interval
             };
-            vm.toggleForm();
+            $location.url(URL.objectToUrlString($rootScope.formData));
         }
 
         vm.submit = function() {

--- a/www/app/shared/searchForm/searchFormDirectives.js
+++ b/www/app/shared/searchForm/searchFormDirectives.js
@@ -33,7 +33,7 @@
     }
 
     function searchReports($rootScope, $location, $timeout) {
-        var reportChange = function (report) {
+        var reportChange = function (report, shouldTriggerSearch) {
             if (report === 'landing_page') {
                 report = $rootScope.philoConfig.search_reports[0];
             } else if (report === "collocation") {
@@ -57,9 +57,11 @@
                 });
             }
             // Note (thawsitt): Triggering click when report type is changed
-            $timeout(function() {
-                angular.element('.input-group-btn #button-search')[0].trigger('click');
-            }, 0);
+            if (shouldTriggerSearch && $rootScope.formData.q) {
+                $timeout(function() {
+                    angular.element('.input-group-btn #button-search').trigger('click');
+                }, 0);
+            }
             return reports
         }
         return {

--- a/www/app/shared/searchForm/searchFormDirectives.js
+++ b/www/app/shared/searchForm/searchFormDirectives.js
@@ -56,6 +56,10 @@
                     label: label
                 });
             }
+            // Note (thawsitt): Triggering click when report type is changed
+            $timeout(function() {
+                angular.element('.input-group-btn #button-search')[0].trigger('click');
+            }, 0);
             return reports
         }
         return {

--- a/www/app/shared/searchForm/searchFormDirectives.js
+++ b/www/app/shared/searchForm/searchFormDirectives.js
@@ -32,7 +32,7 @@
         };
     }
 
-    function searchReports($rootScope, $location) {
+    function searchReports($rootScope, $location, $timeout) {
         var reportChange = function (report) {
             if (report === 'landing_page') {
                 report = $rootScope.philoConfig.search_reports[0];

--- a/www/app/shared/searchForm/searchReports.html
+++ b/www/app/shared/searchForm/searchReports.html
@@ -1,5 +1,5 @@
 <div id="report" class="btn-group btn-group-justified" data-toggle="buttons">
-    <label class="btn btn-primary" ng-class="{'active': report.value === formData.report}" id="{{ ::report.value }}" ng-repeat="report in ::reports" ng-click="reportChange(report.value)">
+    <label class="btn btn-primary" ng-class="{'active': report.value === formData.report}" id="{{ ::report.value }}" ng-repeat="report in ::reports" ng-click="reportChange(report.value, true)">
         <input type="radio" name="{{ ::report.value }}" value="{{ ::report.value }}">
         {{ ::report.label }}
     </label>

--- a/www/webApp.py
+++ b/www/webApp.py
@@ -133,7 +133,8 @@ def load_CSS():
     else:
         css_links = concat_CSS()
     if config.production:
-        return '<link rel="stylesheet" href="app/assets/css/philoLogic.css">'
+        # Cache bust CSS by bumping version number
+        return '<link rel="stylesheet" href="app/assets/css/philoLogic.css?v=1.0.0">'
     else:
         return '\n'.join(css_links)
 

--- a/www/webApp.py
+++ b/www/webApp.py
@@ -133,8 +133,8 @@ def load_CSS():
     else:
         css_links = concat_CSS()
     if config.production:
-        # Cache bust CSS by bumping version number
-        return '<link rel="stylesheet" href="app/assets/css/philoLogic.css?v=1.0.0">'
+        # Note (thawsitt): Bust CSS cache by bumping version number
+        return '<link rel="stylesheet" href="app/assets/css/philoLogic.css?v=1.0.1">'
     else:
         return '\n'.join(css_links)
 


### PR DESCRIPTION
## Metadata Panel
- Move "Show Metadata" button next to TOC button in the middle.
- Remove `Year_Sort` metadata field.
- Add new metadata fields `Source 1` and `Source 2`.

## Other enhancements
- **"Clear" button now reset the whole search.**
- **Switching tabs (e.g. Concordance to Time Series) will now automatically trigger a search.**
- Time series will default to 1200-1400 range if not set specifically.